### PR TITLE
Consistent environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake 

--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,30 @@ __pycache__/
 *.so
 .Python
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
 *.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 .env
 .venv
 env/
 venv/
 ENV/
+.python-version
+.coverage
+htmlcov/
+.pytest_cache/
 
 # Ruby
 *.gem
@@ -26,10 +43,33 @@ ENV/
 
 # Sketchup specific
 *.rbz
+su_mcp_temp/
+
+# Nix
+.direnv/
+.envrc
+result
+result-*
+flake.lock
 
 # OS specific
 .DS_Store
 .DS_Store?
 ._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
 Thumbs.db
 *.tar.gz
+
+# Editor specific
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+logs/
+*.log
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -20,43 +20,164 @@ The system consists of two main components:
 1. **Sketchup Extension**: A Sketchup extension that creates a TCP server within Sketchup to receive and execute commands
 2. **MCP Server (`sketchup_mcp/server.py`)**: A Python server that implements the Model Context Protocol and connects to the Sketchup extension
 
-## Installation
+## Installation and Setup
 
-### Python Packaging
+### Using Nix (Recommended)
 
-We're using uv so you'll need to ```brew install uv```
+We provide a Nix flake for easy setup of the development environment:
 
-### Sketchup Extension
+1. **Prerequisites**:
+   - Install [Nix](https://nixos.org/download.html) with flakes enabled
+   - Optionally install [direnv](https://direnv.net/) for automatic environment activation
 
-1. Download or build the latest `.rbz` file
-2. In Sketchup, go to Window > Extension Manager
-3. Click "Install Extension" and select the downloaded `.rbz` file
-4. Restart Sketchup
+2. **Setup the development environment**:
+   ```bash
+   # Clone the repository
+   git clone https://github.com/yourusername/sketchup-mcp.git
+   cd sketchup-mcp
+   
+   # Enter the Nix development environment
+   nix develop
+   
+   # Or if you use direnv:
+   echo "use flake" > .envrc
+   direnv allow
+   ```
+
+3. **Build the SketchUp extension**:
+   ```bash
+   build-extension
+   ```
+   This will create `su_mcp_v1.6.0.rbz` in the `su_mcp` directory.
+
+4. **Setup Python environment**:
+   ```bash
+   uv venv .venv
+   source .venv/bin/activate
+   uv pip install -e .
+   ```
+
+### Manual Setup (Alternative)
+
+If you prefer not to use Nix:
+
+1. **Prerequisites**:
+   - Ruby with the `rubyzip` gem (`gem install rubyzip`)
+   - Python 3.10+
+   - [UV](https://github.com/astral-sh/uv) package manager (`brew install uv` on macOS)
+
+2. **Build the SketchUp extension**:
+   ```bash
+   cd su_mcp
+   ruby package.rb
+   ```
+   This will create `su_mcp_v1.6.0.rbz` in the `su_mcp` directory.
+
+3. **Setup Python environment**:
+   ```bash
+   uv venv .venv
+   source .venv/bin/activate
+   uv pip install -e .
+   ```
+
+### Installing the SketchUp Extension
+
+1. Open SketchUp
+2. Go to Window > Extension Manager
+3. Click "Install Extension" 
+4. Select the `.rbz` file you built earlier
+5. Restart SketchUp
 
 ## Usage
 
 ### Starting the Connection
 
-1. In Sketchup, go to Extensions > SketchupMCP > Start Server
+1. In SketchUp, go to Extensions > SketchupMCP > Start Server
 2. The server will start on the default port (9876)
-3. Make sure the MCP server is running in your terminal
+3. Run the MCP server in your terminal:
+   ```bash
+   # Make sure you're in the virtual environment
+   source .venv/bin/activate
+   
+   # Run the MCP server
+   sketchup-mcp
+   ```
 
 ### Using with Claude
 
 Configure Claude to use the MCP server by adding the following to your Claude configuration:
 
 ```json
-    "mcpServers": {
-        "sketchup": {
-            "command": "uvx",
-            "args": [
-                "sketchup-mcp"
-            ]
-        }
+"mcpServers": {
+    "sketchup": {
+        "command": "uvx",
+        "args": [
+            "sketchup-mcp"
+        ]
     }
+}
 ```
 
 This will pull the [latest from PyPI](https://pypi.org/project/sketchup-mcp/)
+
+Alternatively, to use your local installation:
+
+```json
+"mcpServers": {
+    "sketchup": {
+        "command": "path/to/your/venv/bin/python",
+        "args": [
+            "-m", "sketchup_mcp.server"
+        ]
+    }
+}
+```
+
+### Using with Cursor
+
+To use SketchupMCP with Cursor:
+
+1. Install the package globally with UV:
+   ```bash
+   uvx install sketchup-mcp
+   ```
+
+2. Update your Cursor MCP configuration file located at `~/.cursor/mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "sketchup": {
+         "command": "uvx",
+         "args": [
+           "sketchup-mcp"
+         ]
+       }
+     }
+   }
+   ```
+
+   If you already have other MCP servers configured, add the sketchup configuration alongside them:
+   ```json
+   {
+     "mcpServers": {
+       "other-server": { /* existing configuration */ },
+       "sketchup": {
+         "command": "uvx",
+         "args": [
+           "sketchup-mcp"
+         ]
+       }
+     }
+   }
+   ```
+
+3. Start the SketchUp server:
+   - Open SketchUp
+   - Go to Extensions > SketchupMCP > Start Server
+   
+4. Now you can use SketchupMCP with Claude in Cursor! The integration will be available when:
+   - SketchUp is running with the server extension started
+   - You use Claude within Cursor
 
 Once connected, Claude can interact with Sketchup using the following capabilities:
 
@@ -87,6 +208,9 @@ Here are some examples of what you can ask Claude to do:
 * **Connection issues**: Make sure both the Sketchup extension server and the MCP server are running
 * **Command failures**: Check the Ruby Console in Sketchup for error messages
 * **Timeout errors**: Try simplifying your requests or breaking them into smaller steps
+* **Extension building errors**: Ensure Ruby and the `rubyzip` gem are properly installed
+* **Python environment errors**: Make sure you're using Python 3.10+ and have activated the virtual environment
+* **Cursor integration issues**: Verify your `~/.cursor/mcp.json` file has the correct configuration
 
 ## Technical Details
 
@@ -96,6 +220,17 @@ The system uses a simple JSON-based protocol over TCP sockets:
 
 * **Commands** are sent as JSON objects with a `type` and optional `params`
 * **Responses** are JSON objects with a `status` and `result` or `message`
+
+## Development
+
+### Project Structure
+
+- `su_mcp/` - Contains the SketchUp extension files
+  - `su_mcp.rb` - Main extension file
+  - `package.rb` - Script to build the .rbz extension file
+- `src/sketchup_mcp/` - Python MCP server implementation
+  - `server.py` - Main server implementation
+- `flake.nix` - Nix development environment configuration
 
 ## Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "SketchupMCP - Sketchup Model Context Protocol Integration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        
+        # Ruby with zip gem for packaging the SketchUp extension
+        rubyWithDeps = pkgs.ruby.withPackages (ps: with ps; [
+          rubyzip
+        ]);
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            # For building the SketchUp extension
+            rubyWithDeps
+            
+            # For the Python MCP server (keep Python dependencies in venv)
+            pkgs.python310
+            pkgs.uv
+            
+            # Useful development tools
+            pkgs.git
+          ];
+
+          shellHook = ''
+            echo "SketchupMCP Development Environment"
+            echo ""
+            echo "Available commands:"
+            echo "  build-extension  - Build the SketchUp extension (.rbz file)"
+            echo ""
+            echo "Note: Python dependencies are managed through venv"
+            echo "  uv venv .venv         - Create virtual environment"
+            echo "  source .venv/bin/activate  - Activate virtual environment"
+            echo "  uv pip install -e .   - Install project in development mode"
+            echo ""
+
+            # Add helper functions
+            function build-extension {
+              echo "Building SketchUp extension..."
+              (cd $PWD/su_mcp && ruby package.rb)
+              echo "Done!"
+            }
+          '';
+        };
+      }
+    );
+} 

--- a/su_mcp/package.rb
+++ b/su_mcp/package.rb
@@ -13,23 +13,27 @@ temp_dir = "#{EXTENSION_NAME}_temp"
 FileUtils.rm_rf(temp_dir) if Dir.exist?(temp_dir)
 FileUtils.mkdir_p(temp_dir)
 
-# Copy files to temp directory
-FileUtils.cp_r('su_mcp', temp_dir)
-FileUtils.cp('su_mcp.rb', temp_dir)
-FileUtils.cp('extension.json', temp_dir)
+begin
+  # Copy files to temp directory
+  FileUtils.cp_r('su_mcp', temp_dir)
+  FileUtils.cp('su_mcp.rb', temp_dir)
+  FileUtils.cp('extension.json', temp_dir)
 
-# Create zip file
-FileUtils.rm(OUTPUT_NAME) if File.exist?(OUTPUT_NAME)
+  # Create zip file
+  FileUtils.rm(OUTPUT_NAME) if File.exist?(OUTPUT_NAME)
 
-Zip::File.open(OUTPUT_NAME, create: true) do |zipfile|
-  Dir["#{temp_dir}/**/**"].each do |file|
-    next if File.directory?(file)
-    puts "Adding: #{file}"
-    zipfile.add(file.sub("#{temp_dir}/", ''), file)
+  Zip::File.open(OUTPUT_NAME, create: true) do |zipfile|
+    Dir["#{temp_dir}/**/**"].each do |file|
+      next if File.directory?(file)
+      puts "Adding: #{file}"
+      zipfile.add(file.sub("#{temp_dir}/", ''), file)
+    end
   end
-end
 
-# Clean up
-FileUtils.rm_rf(temp_dir)
-
-puts "Created #{OUTPUT_NAME}" 
+  puts "Created #{OUTPUT_NAME}"
+ensure
+  # Clean up - this will run even if an error occurs
+  puts "Cleaning up temporary directory..."
+  FileUtils.rm_rf(temp_dir)
+  puts "Cleanup complete."
+end 


### PR DESCRIPTION
I run projects requring various versions of python and ruby. 

Similar to how python manages a virtual python environments, NixOS manages a virtual 'unix' environments.

I use it to lock down dependecies for 'background' deps like python itself, ruby, and uv on a per-project basis.

This PR adds a `flake.nix` and `.envrc` file and updates the README.md:
- With NixOS and direnv installed, automatically sets up the background dependencies (ruby, python, uv etc) when `cd`-ing into this folder or running `nix develop` 
- Adds instructions for manual setup if NixOS is not used
- Updates instructions for how to build the extension

Separately:
- When generating extension tempfile ensures. file is cleaned up. That way it doesn't get committed when the script fails!
